### PR TITLE
refactor(chatbot): update default model name to deepseek-r1:7b

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -17,7 +17,7 @@ class NLPProcessor:
     """Uses Ollama to classify document type and extract structured data as JSON only."""
 
     def __init__(self, ollama_url: str = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate"), 
-                 model_name: str = os.getenv("OLLAMA_MODEL", "llama3:instruct")):
+                 model_name: str = os.getenv("OLLAMA_MODEL", "deepseek-r1:7b")):
         self.ollama_url = ollama_url
         self.model_name = model_name
 


### PR DESCRIPTION
The default model name for the NLPProcessor class has been updated from "llama3:instruct" to "deepseek-r1:7b" to align with the latest model version being used in the system.